### PR TITLE
Fixed wrong file path for npm start

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,29 +1,29 @@
 {
-    "name": "chez-gustave",
-    "private": true,
-    "version": "0.0.0",
-    "main": "src/index.js",
-    "scripts": {
-        "start": "nodemon -L src/index.js",
-        "test": "jest"
-    },
-    "dependencies": {
-        "express": "^4.18.2",
-        "pg": "^8.11.3",
-        "reflect-metadata": "^0.2.1",
-        "typeorm": "^0.3.20"
-    },
-    "devDependencies": {
-        "@jest/globals": "^29.7.0",
-        "@types/express": "^4.17.21",
-        "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.19",
-        "@types/supertest": "^6.0.2",
-        "jest": "^29.7.0",
-        "nodemon": "^3.0.3",
-        "supertest": "^6.3.4",
-        "ts-jest": "^29.1.2",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.3.3"
-    }
+  "name": "chez-gustave",
+  "private": true,
+  "version": "0.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "nodemon -L src/index.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.3",
+    "reflect-metadata": "^0.2.1",
+    "typeorm": "^0.3.20"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.19",
+    "@types/supertest": "^6.0.2",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.3",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,7 @@
   "name": "chez-gustave",
   "private": true,
   "version": "0.0.0",
-  "main": "src/index.js",
+  "main": "src/index.ts",
   "scripts": {
     "start": "nodemon -L src/index.ts",
     "test": "jest"


### PR DESCRIPTION
The `npm start` scripts was starting a javascript file instead of the typescript file, this bug comes from the template.